### PR TITLE
feat: default to sqlalchemy datetime with tz

### DIFF
--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -388,7 +388,7 @@ def get_sqlachemy_type(field: ModelField) -> Any:
     if issubclass(field.type_, int):
         return Integer
     if issubclass(field.type_, datetime):
-        return DateTime
+        return DateTime(timezone=True)
     if issubclass(field.type_, date):
         return Date
     if issubclass(field.type_, timedelta):


### PR DESCRIPTION
Not used to `sqlmodel`, but I think this should do it vs. https://github.com/resights/resights-mono/issues/269

MD mentioned that if we use `sa_column` then primary keys etc need to be moved to this field. Moreover, devs must remember to set `DateTime(timezone=True)`. The goal with this patch is to automate that, so developers can just use the python `datetime.datetime` type annotation, and then we get the timestamptz type in postgres.